### PR TITLE
Add wizard progress stepper

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,13 @@
 import streamlit as st
+from components import render_stepper
 
 st.set_page_config(page_title="賃率ダッシュボード", layout="wide")
 
 st.title("製品賃率ダッシュボード")
 st.caption("📊 Excel（標賃 / R6.12）から賃率KPIを自動計算し、SKU別の達成状況を可視化します。")
+
+# Progress stepper for wizard flow
+render_stepper(0)
 
 st.write("次のページから機能を選択してください。")
 

--- a/components.py
+++ b/components.py
@@ -1,0 +1,25 @@
+import streamlit as st
+
+
+def render_stepper(current_step: int) -> None:
+    """Render a simple progress stepper for the import wizard.
+
+    Parameters
+    ----------
+    current_step: int
+        Zero-based index of the current step. The wizard steps are::
+
+            0: ホーム
+            1: 取り込み
+            2: 自動検証
+            3: 結果サマリ
+            4: ダッシュボード
+    """
+    steps = ["ホーム", "取り込み", "自動検証", "結果サマリ", "ダッシュボード"]
+    total = len(steps) - 1
+    progress = min(max(current_step, 0), total) / total if total else 0.0
+    st.progress(progress)
+    cols = st.columns(len(steps))
+    for idx, (col, label) in enumerate(zip(cols, steps)):
+        prefix = "🔵" if idx <= current_step else "⚪️"
+        col.markdown(f"{prefix} {label}")

--- a/pages/01_データ入力.py
+++ b/pages/01_データ入力.py
@@ -5,8 +5,10 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import streamlit as st
 import pandas as pd
 from utils import read_excel_safely, parse_hyochin, parse_products
+from components import render_stepper
 
 st.title("① データ入力 & 取り込み")
+render_stepper(1)
 
 default_path = "data/sample.xlsx"
 file = st.file_uploader("Excelをアップロード（未指定ならサンプルを使用）", type=["xlsx"])

--- a/pages/02_ダッシュボード.py
+++ b/pages/02_ダッシュボード.py
@@ -9,8 +9,10 @@ import altair as alt
 
 from utils import compute_results
 from standard_rate_core import DEFAULT_PARAMS, sanitize_params, compute_rates
+from components import render_stepper
 
 st.title("② ダッシュボード")
+render_stepper(4)
 scenario_name = st.session_state.get("current_scenario", "ベース")
 st.caption(f"適用中シナリオ: {scenario_name}")
 

--- a/pages/03_標準賃率計算.py
+++ b/pages/03_標準賃率計算.py
@@ -6,6 +6,7 @@ import json
 import streamlit as st
 import numpy as np
 import pandas as pd
+from components import render_stepper
 
 from standard_rate_core import (
     DEFAULT_PARAMS,
@@ -17,6 +18,7 @@ from standard_rate_core import (
 )
 
 st.title("③ 標準賃率 計算/感度分析")
+render_stepper(4)
 scenarios = st.session_state.setdefault("scenarios", {"ベース": st.session_state.get("sr_params", DEFAULT_PARAMS)})
 current = st.session_state.setdefault("current_scenario", "ベース")
 st.caption(f"適用中シナリオ: {current}")


### PR DESCRIPTION
## Summary
- Introduce reusable `render_stepper` component for wizard progress
- Display stepper on home, import, dashboard and standard rate pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b19b2a956483238f55c7d70ccf5fa9