### PR TITLE
Add quick simulation toggles and shareable filter views

### DIFF
--- a/pages/02_ダッシュボード.py
+++ b/pages/02_ダッシュボード.py
@@ -6,6 +6,8 @@ import numpy as np
 import pandas as pd
 import streamlit as st
 import altair as alt
+import plotly.express as px
+from urllib.parse import urlencode
 
 from utils import compute_results
 from standard_rate_core import DEFAULT_PARAMS, sanitize_params, compute_rates
@@ -15,6 +17,9 @@ st.title("② ダッシュボード")
 render_stepper(4)
 scenario_name = st.session_state.get("current_scenario", "ベース")
 st.caption(f"適用中シナリオ: {scenario_name}")
+st.session_state.setdefault("quick_price", 0)
+st.session_state.setdefault("quick_ct", 0)
+st.session_state.setdefault("quick_material", 0)
 
 if "df_products_raw" not in st.session_state or st.session_state["df_products_raw"] is None or len(st.session_state["df_products_raw"]) == 0:
     st.info("先に『① データ入力 & 取り込み』でデータを準備してください。")
@@ -32,54 +37,125 @@ req_rate = base_results["required_rate"]
 for w in warn_list:
     st.warning(w)
 
-rate_lines = []
-for name, p in scenarios.items():
-    sp, _ = sanitize_params(p)
-    _, rr = compute_rates(sp)
-    rate_lines.append({"scenario": name, "type": "必要賃率", "y": rr["required_rate"]})
-    rate_lines.append({"scenario": name, "type": "損益分岐賃率", "y": rr["break_even_rate"]})
-
 with st.expander("表示設定", expanded=False):
     topn = int(st.slider("未達SKUの上位件数（テーブル/パレート）", min_value=5, max_value=50, value=20, step=1))
 
 df = compute_results(df_products_raw, be_rate, req_rate)
 
-# Global filters
-fcol1, fcol2, fcol3, fcol4 = st.columns([1,1,2,2])
+# Global filters with view save/share
 classes = df["rate_class"].dropna().unique().tolist()
-selected_classes = fcol1.multiselect("達成分類で絞り込み", classes, default=classes)
-search = fcol2.text_input("製品名 検索（部分一致）", "")
+global_mpu_min = float(np.nan_to_num(df["minutes_per_unit"].min(), nan=0.0))
+global_mpu_max = float(np.nan_to_num(df["minutes_per_unit"].max(), nan=10.0))
+global_v_min = float(np.nan_to_num(df["va_per_min"].replace([np.inf,-np.inf], np.nan).min(), nan=0.0))
+global_v_max = float(np.nan_to_num(df["va_per_min"].replace([np.inf,-np.inf], np.nan).max(), nan=10.0))
+qparams = st.experimental_get_query_params()
+default_classes = qparams.get("classes", [",".join(classes)])[0].split(",")
+default_classes = [c for c in default_classes if c in classes]
+default_search = qparams.get("search", [""])[0]
+mpu_param = qparams.get("mpu", [f"{global_mpu_min},{global_mpu_max}"])[0]
+try:
+    m_min_q, m_max_q = [float(x) for x in mpu_param.split(",")]
+except Exception:
+    m_min_q, m_max_q = global_mpu_min, global_mpu_max
+vapm_param = qparams.get("vapm", [f"{global_v_min},{global_v_max}"])[0]
+try:
+    v_min_q, v_max_q = [float(x) for x in vapm_param.split(",")]
+except Exception:
+    v_min_q, v_max_q = global_v_min, global_v_max
+fcol1, fcol2, fcol3, fcol4, fcol5, fcol6 = st.columns([1,1,2,2,0.5,0.5])
+selected_classes = fcol1.multiselect("達成分類で絞り込み", classes, default=default_classes)
+search = fcol2.text_input("製品名 検索（部分一致）", default_search)
 mpu_min, mpu_max = fcol3.slider(
     "分/個（製造リードタイム）の範囲",
-    float(np.nan_to_num(df["minutes_per_unit"].min(), nan=0.0)),
-    float(np.nan_to_num(df["minutes_per_unit"].max(), nan=10.0)),
-    value=(0.0, float(np.nan_to_num(df["minutes_per_unit"].max(), nan=10.0)))
+    global_mpu_min,
+    global_mpu_max,
+    value=(m_min_q, m_max_q)
 )
 vapm_min, vapm_max = fcol4.slider(
     "付加価値/分 の範囲",
-    float(np.nan_to_num(df["va_per_min"].replace([np.inf,-np.inf], np.nan).min(), nan=0.0)),
-    float(np.nan_to_num(df["va_per_min"].replace([np.inf,-np.inf], np.nan).max(), nan=10.0)),
-    value=(
-        float(np.nan_to_num(df["va_per_min"].replace([np.inf,-np.inf], np.nan).min(), nan=0.0)),
-        float(np.nan_to_num(df["va_per_min"].replace([np.inf,-np.inf], np.nan).max(), nan=10.0))
-    )
+    global_v_min,
+    global_v_max,
+    value=(v_min_q, v_max_q)
 )
+save_btn = fcol5.button("保存")
+share_btn = fcol6.button("共有")
+if save_btn or share_btn:
+    state = {
+        "classes": ",".join(selected_classes),
+        "search": search,
+        "mpu": f"{mpu_min},{mpu_max}",
+        "vapm": f"{vapm_min},{vapm_max}"
+    }
+    st.experimental_set_query_params(**state)
+    if share_btn:
+        st.session_state["share_link"] = "?" + urlencode(state)
+        st.session_state["show_share"] = True
+    if save_btn:
+        st.session_state["show_saved"] = True
+    st.experimental_rerun()
+if st.session_state.pop("show_saved", False):
+    st.success("ビューを保存しました")
+if st.session_state.pop("show_share", False):
+    st.code(st.session_state.pop("share_link", ""), language=None)
 
 mask = df["rate_class"].isin(selected_classes)
 if search:
     mask &= df["product_name"].astype(str).str.contains(search, na=False)
 mask &= df["minutes_per_unit"].fillna(0.0).between(mpu_min, mpu_max)
 mask &= df["va_per_min"].replace([np.inf,-np.inf], np.nan).fillna(0.0).between(vapm_min, vapm_max)
-df_view = df[mask].copy()
+df_view_filtered = df[mask].copy()
+
+# Quick simulation toggles
+qcol1, qcol2, qcol3, qcol4 = st.columns([1,1,1,0.6])
+with qcol1:
+    st.session_state["quick_price"] = st.radio(
+        "価格", options=[0,3,5,10], format_func=lambda x: f"+{x}%", key="quick_price", horizontal=True
+    )
+with qcol2:
+    st.session_state["quick_ct"] = st.radio(
+        "CT", options=[0,-5,-10], format_func=lambda x: f"{x}%", key="quick_ct", horizontal=True
+    )
+with qcol3:
+    st.session_state["quick_material"] = st.radio(
+        "材料", options=[0,-3,-5], format_func=lambda x: f"{x}%", key="quick_material", horizontal=True
+    )
+with qcol4:
+    if st.button("Undo"):
+        st.session_state["quick_price"] = 0
+        st.session_state["quick_ct"] = 0
+        st.session_state["quick_material"] = 0
+        st.experimental_rerun()
+
+qp = st.session_state["quick_price"]
+qc = st.session_state["quick_ct"]
+qm = st.session_state["quick_material"]
+df_base = df_view_filtered.copy()
+base_ach_rate = (df_base["meets_required_rate"].mean()*100.0) if len(df_base)>0 else 0.0
+base_avg_vapm = df_base["va_per_min"].replace([np.inf,-np.inf], np.nan).dropna().mean() if "va_per_min" in df_base else 0.0
+df_sim = df_base.copy()
+if qp:
+    df_sim["actual_unit_price"] *= (1 + qp/100.0)
+if qc:
+    df_sim["minutes_per_unit"] *= (1 + qc/100.0)
+if qm:
+    df_sim["material_unit_cost"] *= (1 + qm/100.0)
+df_sim["gp_per_unit"] = df_sim["actual_unit_price"] - df_sim["material_unit_cost"]
+df_sim["daily_total_minutes"] = df_sim["minutes_per_unit"] * df_sim["daily_qty"]
+df_sim["daily_va"] = df_sim["gp_per_unit"] * df_sim["daily_qty"]
+with np.errstate(divide='ignore', invalid='ignore'):
+    df_sim["va_per_min"] = df_sim["daily_va"] / df_sim["daily_total_minutes"]
+df_view = compute_results(df_sim, be_rate, req_rate)
+ach_rate = (df_view["meets_required_rate"].mean()*100.0) if len(df_view)>0 else 0.0
+avg_vapm = df_view["va_per_min"].replace([np.inf,-np.inf], np.nan).dropna().mean() if "va_per_min" in df_view else 0.0
+if qp or qc or qm:
+    st.caption(f"Quick試算中: 価格{qp:+d}%, CT{qc:+d}%, 材料{qm:+d}%")
 
 # KPI cards
 col1, col2, col3, col4 = st.columns(4)
 col1.metric("必要賃率 (円/分)", f"{req_rate:,.3f}")
 col2.metric("損益分岐賃率 (円/分)", f"{be_rate:,.3f}")
-ach_rate = (df_view["meets_required_rate"].mean()*100.0) if len(df_view)>0 else 0.0
-col3.metric("必要賃率達成SKU比率", f"{ach_rate:,.1f}%")
-avg_vapm = df_view["va_per_min"].replace([np.inf,-np.inf], np.nan).dropna().mean() if "va_per_min" in df_view else 0.0
-col4.metric("平均 付加価値/分", f"{avg_vapm:,.1f}")
+col3.metric("必要賃率達成SKU比率", f"{ach_rate:,.1f}%", delta=f"{ach_rate-base_ach_rate:,.1f}%")
+col4.metric("平均 付加価値/分", f"{avg_vapm:,.1f}", delta=f"{avg_vapm-base_avg_vapm:,.1f}")
 
 # Actionable SKU Top List
 st.subheader("要対策SKUトップリスト")
@@ -134,18 +210,30 @@ else:
 tabs = st.tabs(["全体分布（散布図）", "達成状況（棒/円）", "未達SKU（パレート）", "SKUテーブル", "付加価値/分分布"])
 
 with tabs[0]:
-    st.caption("横軸=分/個（製造リードタイム）, 縦軸=付加価値/分。色線=各シナリオの必要賃率と損益分岐賃率。")
-    base = alt.Chart(df_view).mark_circle().encode(
-        x=alt.X("minutes_per_unit:Q", title="分/個"),
-        y=alt.Y("va_per_min:Q", title="付加価値/分", scale=alt.Scale(domain=(vapm_min, vapm_max))),
-        tooltip=["product_name:N","minutes_per_unit:Q","va_per_min:Q","rate_class:N"]
-    ).properties(height=420)
-    color = base.encode(color=alt.Color("rate_class:N", legend=alt.Legend(title="分類")))
-    rule_chart = alt.Chart(pd.DataFrame(rate_lines)).mark_rule().encode(
-        y="y:Q", color="scenario:N", strokeDash="type:N"
+    st.caption("横軸=分/個（製造リードタイム）, 縦軸=付加価値/分。必要賃率±5%帯と損益分岐賃率を表示。")
+    df_view["margin_to_req"] = req_rate - df_view["va_per_min"]
+    color_map = {"健康商品": "#009E73", "貧血商品": "#0072B2", "出血商品": "#D55E00", "不明": "#999999"}
+    symbol_map = {"健康商品": "circle", "貧血商品": "triangle-up", "出血商品": "square", "不明": "x"}
+    fig = px.scatter(
+        df_view,
+        x="minutes_per_unit",
+        y="va_per_min",
+        color="rate_class",
+        symbol="rate_class",
+        color_discrete_map=color_map,
+        symbol_map=symbol_map,
+        hover_data={
+            "product_name": True,
+            "minutes_per_unit": ":.2f",
+            "va_per_min": ":.2f",
+            "margin_to_req": ":.2f",
+        },
+        height=420,
     )
-    layered = (color + rule_chart).resolve_scale(color="independent")
-    st.altair_chart(layered, use_container_width=True)
+    fig.add_hrect(y0=req_rate*0.95, y1=req_rate*1.05, line_width=0, fillcolor="#009E73", opacity=0.15)
+    fig.add_hline(y=req_rate, line_color="#009E73")
+    fig.add_hline(y=be_rate, line_color="#D55E00", line_dash="dash")
+    st.plotly_chart(fig, use_container_width=True)
 
 with tabs[1]:
     c1, c2 = st.columns([1.2,1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ altair>=5.0.0
 matplotlib>=3.7.0
 reportlab>=4.0.0
 streamlit_js_eval>=0.1.0
+plotly>=5.0.0


### PR DESCRIPTION
## Summary
- Add Plotly-based scatter plot with required/break-even rate bands and margin tooltip
- Introduce quick simulation toggles for price, cycle time and material cost with KPI deltas and undo
- Enable filter view save and share via URL query parameters
- Include Plotly in project dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1a0a6934083239a4e72c6f0fa63aa