### PR TITLE
Improve navigation with sidebar links

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
 import streamlit as st
-from components import render_stepper
+from components import render_stepper, render_sidebar_nav
 
 st.set_page_config(page_title="賃率ダッシュボード", layout="wide")
+
+render_sidebar_nav()
 
 st.title("製品賃率ダッシュボード")
 st.caption("📊 Excel（標賃 / R6.12）から賃率KPIを自動計算し、SKU別の達成状況を可視化します。")

--- a/components.py
+++ b/components.py
@@ -23,3 +23,12 @@ def render_stepper(current_step: int) -> None:
     for idx, (col, label) in enumerate(zip(cols, steps)):
         prefix = "🔵" if idx <= current_step else "⚪️"
         col.markdown(f"{prefix} {label}")
+
+
+def render_sidebar_nav() -> None:
+    """Render sidebar navigation links across pages."""
+    st.sidebar.header("ナビゲーション")
+    st.sidebar.page_link("app.py", label="ホーム", icon="🏠")
+    st.sidebar.page_link("pages/01_データ入力.py", label="① データ入力", icon="📥")
+    st.sidebar.page_link("pages/02_ダッシュボード.py", label="② ダッシュボード", icon="📊")
+    st.sidebar.page_link("pages/03_標準賃率計算.py", label="③ 標準賃率計算", icon="🧮")

--- a/pages/01_データ入力.py
+++ b/pages/01_データ入力.py
@@ -5,9 +5,10 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import streamlit as st
 import pandas as pd
 from utils import read_excel_safely, parse_hyochin, parse_products
-from components import render_stepper
+from components import render_stepper, render_sidebar_nav
 
 st.title("① データ入力 & 取り込み")
+render_sidebar_nav()
 render_stepper(1)
 
 default_path = "data/sample.xlsx"

--- a/pages/02_ダッシュボード.py
+++ b/pages/02_ダッシュボード.py
@@ -11,9 +11,10 @@ from urllib.parse import urlencode
 
 from utils import compute_results
 from standard_rate_core import DEFAULT_PARAMS, sanitize_params, compute_rates
-from components import render_stepper
+from components import render_stepper, render_sidebar_nav
 
 st.title("② ダッシュボード")
+render_sidebar_nav()
 render_stepper(4)
 scenario_name = st.session_state.get("current_scenario", "ベース")
 st.caption(f"適用中シナリオ: {scenario_name}")

--- a/pages/03_標準賃率計算.py
+++ b/pages/03_標準賃率計算.py
@@ -6,7 +6,7 @@ import json
 import streamlit as st
 import numpy as np
 import pandas as pd
-from components import render_stepper
+from components import render_stepper, render_sidebar_nav
 
 from standard_rate_core import (
     DEFAULT_PARAMS,
@@ -18,6 +18,7 @@ from standard_rate_core import (
 )
 
 st.title("③ 標準賃率 計算/感度分析")
+render_sidebar_nav()
 render_stepper(4)
 scenarios = st.session_state.setdefault("scenarios", {"ベース": st.session_state.get("sr_params", DEFAULT_PARAMS)})
 current = st.session_state.setdefault("current_scenario", "ベース")


### PR DESCRIPTION
## Summary
- add reusable sidebar navigation component
- show sidebar links on all pages for easier movement

## Testing
- `pytest -q`
- `timeout 5 streamlit run app.py --server.headless true --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_68b1bc50ffa483239f81c5781d53a4db