### PR TITLE
feat: add data quality indicator

### DIFF
--- a/test_quality.py
+++ b/test_quality.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from utils import detect_quality_issues
+
+
+def test_detect_quality_issues():
+    df = pd.DataFrame({
+        "product_no": [1, 1, 2, 3],
+        "product_name": ["A", "A", "B", "C"],
+        "actual_unit_price": [100, 100, None, -50],
+        "material_unit_cost": [10, 10, 20, 30],
+        "minutes_per_unit": [1, 1, 2, 3],
+        "daily_qty": [10, 10, 20, 30],
+    })
+    issues = detect_quality_issues(df)
+    kinds = set(issues["type"].tolist())
+    assert {"欠損", "外れ値", "重複"} == kinds
+    assert (issues["type"] == "重複").sum() == 1
+    assert any((issues["type"] == "欠損") & (issues["column"] == "actual_unit_price"))
+    assert any((issues["type"] == "外れ値") & (issues["product_no"] == 3))


### PR DESCRIPTION
## Summary
- detect missing, negative and duplicate product data
- display data quality badge and error list with exclusion toggle on dashboard
- add unit test for quality issue detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c6140408832399c94437683fa3f1