### PR TITLE
feat: add refined theme

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,3 +1,8 @@
 [theme]
-base="light"
-primaryColor="#009E73"
+# Deep navy base with subtle green accent
+base = "dark"
+primaryColor = "#2E8B57"
+backgroundColor = "#0B1E39"
+secondaryBackgroundColor = "#1B2A41"
+textColor = "#E0E0E0"
+font = "sans serif"

--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
 import streamlit as st
 from core.constants import DEFAULT_MASTER, DEFAULT_SCENARIO
+from ui.theming import apply_theme
 
 st.set_page_config(page_title="賃率ダッシュボード", layout="wide")
+apply_theme()
 
 st.title("製品賃率ダッシュボード")
 st.caption("製造業向けの標準賃率計算ツール")

--- a/ui/pages/1_📊_ダッシュボード.py
+++ b/ui/pages/1_📊_ダッシュボード.py
@@ -3,7 +3,9 @@ from core.constants import DEFAULT_MASTER, DEFAULT_SCENARIO
 from core.models import Master, Scenario, Result
 from core.formulas import compute_rates
 from ui.widgets import kpi_tile, sticky_control_bar
+from ui.theming import apply_theme
 
+apply_theme()
 st.title("📊 ダッシュボード")
 
 master_dict = st.session_state.get("master", DEFAULT_MASTER.model_dump())

--- a/ui/pages/2_🧮_入力_マスター.py
+++ b/ui/pages/2_🧮_入力_マスター.py
@@ -4,7 +4,9 @@ from pydantic import ValidationError
 from core.constants import DEFAULT_MASTER
 from core.models import Master
 from ui.widgets import sticky_control_bar
+from ui.theming import apply_theme
 
+apply_theme()
 st.title("🧮 入力 マスター")
 
 master_dict = st.session_state.get("master", DEFAULT_MASTER.model_dump())

--- a/ui/pages/3_🧪_シミュレーション.py
+++ b/ui/pages/3_🧪_シミュレーション.py
@@ -8,7 +8,9 @@ from core.formulas import compute_rates
 from core.constants import DEFAULT_MASTER, DEFAULT_SCENARIO
 from core.audit import AuditLog
 from ui.widgets import kpi_tile, sticky_control_bar
+from ui.theming import apply_theme
 
+apply_theme()
 st.title("🧪 シミュレーション")
 
 master_dict = st.session_state.get("master", DEFAULT_MASTER.model_dump())

--- a/ui/pages/4_📑_結果_エクスポート.py
+++ b/ui/pages/4_📑_結果_エクスポート.py
@@ -2,7 +2,9 @@ import json
 import streamlit as st
 from core.models import Result
 from ui.widgets import sticky_control_bar
+from ui.theming import apply_theme
 
+apply_theme()
 st.title("📑 結果 エクスポート")
 
 if "result" in st.session_state:

--- a/ui/pages/9_🛠️_DevTools_ログ.py
+++ b/ui/pages/9_🛠️_DevTools_ログ.py
@@ -1,7 +1,9 @@
 import streamlit as st
 from core.audit import AuditLog
 from ui.widgets import sticky_control_bar
+from ui.theming import apply_theme
 
+apply_theme()
 st.title("🛠️ DevTools ログ")
 
 log: AuditLog | None = st.session_state.get("audit")

--- a/ui/styles/mckinsey.css
+++ b/ui/styles/mckinsey.css
@@ -1,0 +1,36 @@
+/* McKinsey-style refined theme */
+
+html, body, [data-testid="stAppViewContainer"], .stApp {
+    background-color: #0B1E39;
+    color: #E0E0E0;
+    font-family: 'Helvetica', 'Arial', sans-serif;
+    line-height: 1.6;
+}
+
+.block-container {
+    padding: 2rem 3rem;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    color: #FFFFFF;
+}
+
+.stButton>button {
+    background-color: #2E8B57;
+    color: #FFFFFF;
+    border: none;
+    border-radius: 4px;
+    transition: background-color 0.3s ease;
+}
+
+.stButton>button:hover {
+    background-color: #25724A;
+}
+
+a {
+    color: #3A7CA5;
+}
+

--- a/ui/theming.py
+++ b/ui/theming.py
@@ -1,8 +1,9 @@
-"""Theme synchronisation utilities."""
-import json
+"""Theme utilities for applying a McKinsey-style design."""
 from pathlib import Path
+import streamlit as st
 
 CONFIG_PATH = Path(".streamlit/config.toml")
+STYLE_PATH = Path("ui/styles/mckinsey.css")
 
 
 def load_theme() -> dict:
@@ -10,3 +11,10 @@ def load_theme() -> dict:
     if CONFIG_PATH.exists():
         return {"config_path": str(CONFIG_PATH)}
     return {}
+
+
+def apply_theme() -> None:
+    """Inject global CSS for a calm and refined design."""
+    if STYLE_PATH.exists():
+        css = STYLE_PATH.read_text()
+        st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- establish deep navy theme with subtle green accents
- inject global CSS for refined typography and spacing
- apply theme across all Streamlit pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b459d89bd08323bed5fa3b44253c70