### PR TITLE
feat: add generative AI summaries and explanations

### DIFF
--- a/core/genai.py
+++ b/core/genai.py
@@ -1,0 +1,88 @@
+"""Generative AI helpers for summary and explanations.
+
+This module provides light wrappers that call OpenAI's API when available
+for summarising input data, generating comments and explaining numerical
+analysis results.  If the OpenAI client or API key is not configured, the
+functions gracefully fall back to simple template-based messages so that the
+rest of the application continues to operate without external dependencies.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from .models import Master, Scenario, Result
+
+
+def _openai_response(prompt: str) -> Optional[str]:
+    """Return a response from OpenAI's chat completions API if possible.
+
+    The function checks for the presence of the ``openai`` package and the
+    ``OPENAI_API_KEY`` environment variable.  Any import errors or API
+    failures result in ``None`` being returned so callers can provide
+    fallbacks.
+    """
+    try:
+        from openai import OpenAI  # type: ignore
+    except Exception:
+        return None
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+
+    client = OpenAI(api_key=api_key)
+    try:
+        completion = client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.3,
+            max_tokens=200,
+        )
+    except Exception:
+        return None
+
+    message = completion.choices[0].message
+    return getattr(message, "content", None)
+
+
+def summarize_inputs(master: Master, scenario: Scenario) -> str:
+    """Summarise master and scenario data using a language model."""
+    prompt = (
+        "以下の製造コストデータを50字程度で要約してください:\n"  # noqa: E501
+        f"マスター: {master.model_dump()}\nシナリオ: {scenario.model_dump()}"
+    )
+    response = _openai_response(prompt)
+    if response:
+        return response.strip()
+    return (
+        f"人件費は年{master.direct_labor_cost}円、稼働率は{scenario.availability_rate}、"  # noqa: E501
+        f"良品率は{scenario.yield_rate}です。"
+    )
+
+
+def explain_result(result: Result) -> str:
+    """Provide an automatic explanation of analysis results."""
+    prompt = (
+        "必要賃率と損益分岐賃率の結果を業務担当者向けに短く説明してください。\n"  # noqa: E501
+        f"結果データ: {result.model_dump()}"
+    )
+    response = _openai_response(prompt)
+    if response:
+        return response.strip()
+    return (
+        f"必要賃率は{result.required_rate}円/時で、損益分岐賃率は"  # noqa: E501
+        f"{result.break_even_rate}円/時、実稼働時間は{result.actual_operating_hours}時間です。"  # noqa: E501
+    )
+
+
+def generate_comment(result: Result) -> str:
+    """Generate a suggestion or comment based on the result numbers."""
+    prompt = (
+        "以下の結果に対する改善コメントを日本語で提案してください。\n"  # noqa: E501
+        f"結果データ: {result.model_dump()}"
+    )
+    response = _openai_response(prompt)
+    if response:
+        return response.strip()
+    return "コスト構成を見直し、稼働率や良品率の向上を検討してください。"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Minimal dependencies for core functionality.
 # UI-related packages were removed to avoid heavy build requirements.
 pydantic==2.6.4
+openai>=1.0.0

--- a/ui/pages/1_📊_ダッシュボード.py
+++ b/ui/pages/1_📊_ダッシュボード.py
@@ -2,6 +2,7 @@ import streamlit as st
 from core.constants import DEFAULT_MASTER, DEFAULT_SCENARIO
 from core.models import Master, Scenario, Result
 from core.formulas import compute_rates
+from core.genai import summarize_inputs
 from ui.widgets import kpi_tile, sticky_control_bar
 from ui.theming import apply_theme
 
@@ -11,14 +12,17 @@ st.title("📊 ダッシュボード")
 master_dict = st.session_state.get("master", DEFAULT_MASTER.model_dump())
 scenario_dict = st.session_state.get("scenario", DEFAULT_SCENARIO.model_dump())
 
+master = Master(**master_dict)
+scenario = Scenario(**scenario_dict)
 if "result" not in st.session_state:
-    master = Master(**master_dict)
-    scenario = Scenario(**scenario_dict)
     res = compute_rates(master, scenario)
     st.session_state["result"] = res.model_dump()
 
 res = Result(**st.session_state["result"])
 kpi_tile("必要賃率 (円/時)", res.required_rate)
 kpi_tile("損益分岐賃率 (円/時)", res.break_even_rate)
+
+st.subheader("AI要約")
+st.write(summarize_inputs(master, scenario))
 
 sticky_control_bar(master_dict, scenario_dict)

--- a/ui/pages/3_🧪_シミュレーション.py
+++ b/ui/pages/3_🧪_シミュレーション.py
@@ -7,6 +7,7 @@ from core.models import Master, Scenario, Result
 from core.formulas import compute_rates
 from core.constants import DEFAULT_MASTER, DEFAULT_SCENARIO
 from core.audit import AuditLog
+from core.genai import explain_result, generate_comment
 from ui.widgets import kpi_tile, sticky_control_bar
 from ui.theming import apply_theme
 
@@ -55,6 +56,12 @@ if "result" in st.session_state:
     res = Result(**st.session_state["result"])
     kpi_tile("必要賃率 (円/時)", res.required_rate)
     kpi_tile("損益分岐賃率 (円/時)", res.break_even_rate)
+
+    st.subheader("AI解説")
+    st.write(explain_result(res))
+
+    st.subheader("AIコメント")
+    st.write(generate_comment(res))
 
     master = Master(**master_dict)
     components = [


### PR DESCRIPTION
## Summary
- integrate OpenAI-powered summaries for master and scenario data
- provide AI-generated explanations and improvement comments for simulation results
- add optional generative AI utility module and dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a0085c8483239a6a170ceb8d3be3